### PR TITLE
Fix: Correct port configuration for Render deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,6 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
-
-    - name: Display Dockerfile content
-      run: cat Dockerfile
     
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/server/prod.ts
+++ b/server/prod.ts
@@ -44,7 +44,7 @@ app.use(express.urlencoded({ extended: false }));
     serveStatic(app);
   }
 
-  const port = parseInt(process.env.PORT || '5000', 10);
+  const port = parseInt(process.env.PORT || '5001', 10);
   server.listen({
     port,
     host: "0.0.0.0",


### PR DESCRIPTION
This commit addresses two issues:
1. The backend server was using a default port (`5000`) in production that did not match the port expected by the Dockerfile's HEALTHCHECK (`5001`). This caused the service to fail its health checks and be terminated on Render. The default production port has been changed to `5001` to match the health check. The server will still correctly use the `PORT` environment variable when provided by Render.
2. A temporary debugging step that was added to the `ci.yml` workflow has been removed.

These changes should result in a stable deployment on Render.